### PR TITLE
Add support for multiple tags on single lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,32 +45,35 @@ These instructions will get you a copy of the project up and running on your loc
 ## Usage
 
     Usage: reformat-gherkin [OPTIONS] [SRC]...
-    
+
       Reformat the given Gherkin files and all files in the given directories
       recursively.
-    
+
     Options:
-      --check                       Don't write the files back, just return the
-                                    status. Return code 0 means nothing would
-                                    change. Return code 1 means some files would
-                                    be reformatted. Return code 123 means there
-                                    was an internal error.
-      -a, --alignment [left|right]  Specify the alignment of step keywords (Given,
-                                    When, Then,...). If specified, all statements
-                                    after step keywords are left-aligned, spaces
-                                    are inserted before/after the keywords to
-                                    right/left align them. By default, step
-                                    keywords are left-aligned, and there is a
-                                    single space between the step keyword and the
-                                    statement.
-      -n, --newline [LF|CRLF]       Specify the line separators when formatting
-                                    files inplace. If not specified, line
-                                    separators are preserved.
-      --fast / --safe               If --fast given, skip the sanity checks of
-                                    file contents. [default: --safe]
-      --config FILE                 Read configuration from FILE.
-      --version                     Show the version and exit.
-      --help                        Show this message and exit.
+      --check                         Don't write the files back, just return the
+                                      status. Return code 0 means nothing would
+                                      change. Return code 1 means some files would
+                                      be reformatted. Return code 123 means there
+                                      was an internal error.
+      -a, --alignment [left|right]    Specify the alignment of step keywords
+                                      (Given, When, Then,...). If specified, all
+                                      statements after step keywords are left-
+                                      aligned, spaces are inserted before/after
+                                      the keywords to right/left align them. By
+                                      default, step keywords are left-aligned, and
+                                      there is a single space between the step
+                                      keyword and the statement.
+      -n, --newline [LF|CRLF]         Specify the line separators when formatting
+                                      files inplace. If not specified, line
+                                      separators are preserved.
+      -t, --taglines [singleline|multiline]
+                                      Specify whether tags should be placed on a
+                                      single line or spaced across multiple lines.
+      --fast / --safe                 If --fast given, skip the sanity checks of
+                                      file contents. [default: --safe]
+      --config FILE                   Read configuration from FILE.
+      --version                       Show the version and exit.
+      --help                          Show this message and exit.
 
 ### Config file
 

--- a/reformat_gherkin/cli.py
+++ b/reformat_gherkin/cli.py
@@ -5,7 +5,7 @@ import click
 from .config import read_config_file
 from .core import reformat
 from .errors import EmptySources
-from .options import AlignmentMode, NewlineMode, Options, WriteBackMode
+from .options import AlignmentMode, NewlineMode, TagLineMode, Options, WriteBackMode
 from .report import Report
 from .utils import out
 from .version import __version__
@@ -51,6 +51,15 @@ from .version import __version__
     ),
 )
 @click.option(
+    "-t",
+    "--taglines",
+    type=click.Choice([TagLineMode.SINGLELINE.value, TagLineMode.MULTILINE.value]),
+    help=(
+        "Specify whether tags should be placed on a single line or spaced "
+        "across multiple lines."
+    ),
+)
+@click.option(
     "--fast/--safe",
     is_flag=True,
     help="If --fast given, skip the sanity checks of file contents. [default: --safe]",
@@ -72,6 +81,7 @@ def main(
     check: bool,
     alignment: Optional[str],
     newline: Optional[str],
+    taglines: Optional[str],
     fast: bool,
     config: Optional[str],
 ) -> None:
@@ -84,11 +94,13 @@ def main(
     write_back_mode = WriteBackMode.from_configuration(check)
     alignment_mode = AlignmentMode.from_configuration(alignment)
     newline_mode = NewlineMode.from_configuration(newline)
+    tag_line_mode = TagLineMode.from_configuration(taglines)
 
     options = Options(
         write_back=write_back_mode,
         step_keyword_alignment=alignment_mode,
         newline=newline_mode,
+        tag_line_mode=tag_line_mode,
         fast=fast,
     )
 

--- a/reformat_gherkin/core.py
+++ b/reformat_gherkin/core.py
@@ -106,7 +106,7 @@ def format_str(src_contents: str, *, options: Options) -> str:
     """
     ast = parse(src_contents)
 
-    line_generator = LineGenerator(ast, options.step_keyword_alignment)
+    line_generator = LineGenerator(ast, options.step_keyword_alignment, options.tag_line_mode)
     lines = line_generator.generate()
 
     return "\n".join(lines)

--- a/reformat_gherkin/formatter.py
+++ b/reformat_gherkin/formatter.py
@@ -258,25 +258,23 @@ class LineGenerator:
 
     def generate(self) -> Lines:
         i = 0
-        if self.tag_line_mode == TagLineMode.SINGLELINE:
-            tags = []
-            for i, node in enumerate(self.__nodes):
-                if type(node).__name__ == "Tag":
-                    tags.append(node)
-                elif type(node).__name__ == "Comment":
-                    yield from self.visit_tags(tags)
-                    yield from self.visit(node)
-                    tags.clear()
-                else:
-                    break
+        while i < len(self.__nodes):
+            node = self.__nodes[i]
+            if self.tag_line_mode == TagLineMode.SINGLELINE and type(node).__name__ == "Tag":
+                tags = []
+                for n, node in enumerate(self.__nodes[i:]):
+                    if type(node).__name__ == "Tag":
+                        tags.append(node)
+                    else:
+                        yield from self.visit_tags(tags)
+                        break
+                i += n - 1
+            else:
+                yield from self.visit(node)
 
-            yield from self.visit_tags(tags)
-
-        for node in self.__nodes[i:]:
-            yield from self.visit(node)
-
-            if node in self.__nodes_with_newline:
-                yield ""
+                if node in self.__nodes_with_newline:
+                    yield ""
+            i += 1
 
     def visit(self, node: Node) -> Lines:
         class_name = type(node).__name__

--- a/reformat_gherkin/options.py
+++ b/reformat_gherkin/options.py
@@ -36,9 +36,21 @@ class NewlineMode(Enum):
         return NewlineMode(newline)
 
 
+@unique
+class TagLineMode(Enum):
+    NONE = None
+    SINGLELINE = "singleline"
+    MULTILINE = "multiline"
+
+    @classmethod
+    def from_configuration(cls, taglinemode: Optional[str]) -> "TagLineMode":
+        return TagLineMode(taglinemode)
+
+
 @dataclass(frozen=True)
 class Options:
     write_back: WriteBackMode
     step_keyword_alignment: AlignmentMode
     newline: NewlineMode
+    tag_line_mode: TagLineMode
     fast: bool

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,10 +1,11 @@
-from reformat_gherkin.options import AlignmentMode, NewlineMode, Options, WriteBackMode
+from reformat_gherkin.options import AlignmentMode, NewlineMode, Options, TagLineMode, WriteBackMode
 
 OPTIONS = [
     Options(
         write_back=WriteBackMode.CHECK,
         step_keyword_alignment=alignment_mode,
         newline=NewlineMode.KEEP,
+        tag_line_mode=TagLineMode.MULTILINE,
         fast=False,
     )
     for alignment_mode in AlignmentMode


### PR DESCRIPTION
This PR adds support for handling multiple tags on single lines, opposed to the default behavior of putting each tag on its own line.

Our motivation for making this change is to allow `reformat-gherkin` to play nicely with `pytest-bdd`, which only recognizes single-line tags as valid gherkin.

Here's an example with `-t multiline` (the default, and current behavior):
``` gherkin
Feature: Some feature name
  Some description

  Background:
    Given a foo

  # comment 1
  @one
  @two
  @three
  # comment 2
  # comment 3
  @four
  @five
  Scenario: Some scenario name
    Given a bar
    When I foo bar
    Then bar is foo'd
    
```

and here is how it would be formatted with `-t singleline`:
``` gherkin
Feature: Some feature name
  Some description

  Background:
    Given a foo

  # comment 1
  @one @two @three
  # comment 2
  # comment 3
  @four @five
  Scenario: Some scenario name
    Given a bar
    When I foo bar
    Then bar is foo'd
    
```