### PR TITLE
Align tables containing wide or zero-width characters

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = attr,cattr,click,gherkin,pytest,yaml
+known_third_party = attr,cattr,click,gherkin,pytest,wcwidth,yaml
 line_length = 88
 multi_line_output = 3
 force_grid_wrap = 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,7 +275,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 version = "16.7.9"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
 optional = false
@@ -295,7 +295,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "3df6810a2c24c2d1f50af87e7cc67b4f6c2a77a82903fd8694101c93f30c1f41"
+content-hash = "8623210463850d01042d77922b3571edf8c77c8a812540158b99c606b7666e90"
 python-versions = "^3.6"
 
 [metadata.hashes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ click = "^7.0"
 attrs = "^19.2"
 cattrs = "^0.9.0"
 pyyaml = "^5.1"
+wcwidth = "^0.1.7"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^1.14"

--- a/reformat_gherkin/formatter.py
+++ b/reformat_gherkin/formatter.py
@@ -20,7 +20,12 @@ from .ast_node import (
     Tag,
 )
 from .options import AlignmentMode
-from .utils import camel_to_snake_case, extract_beginning_spaces, get_step_keywords
+from .utils import (
+    camel_to_snake_case,
+    extract_beginning_spaces,
+    get_display_width,
+    get_step_keywords,
+)
 
 INDENT = "  "
 INDENT_LEVEL_MAP: Mapping[Any, int] = {
@@ -127,7 +132,7 @@ def generate_table_lines(rows: List[TableRow]) -> List[str]:
     # Find the max width of a cell in a column, so that every cell in the same column
     # has the same width
     column_widths = [
-        max(len(row[column_index].value) for row in rows)
+        max(get_display_width(row[column_index].value) for row in rows)
         for column_index in range(n_columns)
     ]
 
@@ -138,8 +143,10 @@ def generate_table_lines(rows: List[TableRow]) -> List[str]:
         for column_index in range(n_columns):
             # Left-align the content of each cell, fix the width of the cell
             content = row[column_index].value
-            width = column_widths[column_index]
-            line += f" {content:<{width}} |"
+            column_width = column_widths[column_index]
+            content_width = get_display_width(content)
+            padding = " " * (column_width - content_width)
+            line += f" {content}{padding} |"
 
         lines.append(line)
 

--- a/reformat_gherkin/utils.py
+++ b/reformat_gherkin/utils.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 import click
 from gherkin.dialect import Dialect
+from wcwidth import wcswidth
 
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)
@@ -92,3 +93,23 @@ def decode_bytes(src: bytes) -> Tuple[str, str, str]:
     srcbuf.seek(0)
     with io.TextIOWrapper(srcbuf, encoding) as tiow:
         return tiow.read(), encoding, newline
+
+
+def get_display_width(text: str) -> int:
+    """
+    Get the display width of a string.
+
+    When displayed in a console, some characters can have a width of 2 (for
+    example, East Asian characters) or a width of 0 (for example, combining
+    diacritic characters). Use the wcwidth package to find the correct display
+    width for strings including these characters.
+
+    Some characters do not have a width (for example, control characters like
+    the bell character). If a string contains any such characters, then
+    wcwidth.wcswidth returns -1. In this case, use the number of code points as
+    a fallback.
+    """
+    width = wcswidth(text)
+    if width < 0:
+        width = len(text)
+    return width

--- a/tests/data/expected/character_width.feature
+++ b/tests/data/expected/character_width.feature
@@ -1,0 +1,27 @@
+Feature: Character width
+
+  Scenario: Aligning tables
+    Given a table of strings containing wide characters
+      | aaa    |
+      | あああ |
+    And a table of strings containing combining characters
+      | aaa |
+      | ááá |
+    When I run reformat-gherkin
+    Then the tables should be aligned
+
+  Scenario Outline: Aligning wide character examples
+    Then examples tables containing '<string>' should be aligned
+
+    Examples:
+      | string           |
+      | aaaaaaaa         |
+      | ああああああああ |
+
+  Scenario Outline: Aligning combining character examples
+    Then examples tables containing '<string>' should be aligned
+
+    Examples:
+      | string   |
+      | aaaaaaaa |
+      | áááááááá |

--- a/tests/data/valid/character_width.feature
+++ b/tests/data/valid/character_width.feature
@@ -1,0 +1,27 @@
+Feature: Character width
+
+  Scenario: Aligning tables
+    Given a table of strings containing wide characters
+      | aaa |
+      | あああ |
+    And a table of strings containing combining characters
+      | aaa |
+      | ááá |
+    When I run reformat-gherkin
+    Then the tables should be aligned
+
+  Scenario Outline: Aligning wide character examples
+    Then examples tables containing '<string>' should be aligned
+
+    Examples:
+      | string |
+      | aaaaaaaa |
+      | ああああああああ |
+
+  Scenario Outline: Aligning combining character examples
+    Then examples tables containing '<string>' should be aligned
+
+    Examples:
+      | string |
+      | aaaaaaaa |
+      | áááááááá |

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,3 +62,25 @@ def test_decode_bytes():
 
         assert contents == lines
         assert _newline == newline
+
+
+@pytest.mark.parametrize(
+    ["text", "width"],
+    [
+        ("abc", 3),
+        ("あああ", 6),
+        ("1.5倍", 5),
+        ("😍", 2),
+        ("１２３", 6),
+        ("ááá", 3),  # Combining diacritics
+        ("ááá", 3),  # Single-character diacritics
+        ("aaa\b", 4),
+        ("\t", 1),
+        ("", 0),
+        ("\\|", 2),  # Gherkin pipe escape sequence
+        ("\u202f", 1),  # Narrow no-break space
+        ("\u200d", 0),  # Zero width joiner
+    ],
+)
+def test_get_display_width(text, width):
+    assert utils.get_display_width(text) == width


### PR DESCRIPTION
When printed in a fixed-width font, some characters take up two columns
(e.g. East Asian characters or emojis) and some characters take up zero
columns (like combining diacritic characters). To take these characters
into account when aligning tables, use the wcwidth package to get the
display length of the table cell contents.

Fixes #18