### PR TITLE
Allow formatting tags on a single line

### DIFF
--- a/reformat_gherkin/cli.py
+++ b/reformat_gherkin/cli.py
@@ -5,7 +5,7 @@ import click
 from .config import read_config_file
 from .core import reformat
 from .errors import EmptySources
-from .options import AlignmentMode, NewlineMode, Options, WriteBackMode
+from .options import AlignmentMode, NewlineMode, Options, TagLineMode, WriteBackMode
 from .report import Report
 from .utils import out
 from .version import __version__
@@ -51,6 +51,16 @@ from .version import __version__
     ),
 )
 @click.option(
+    "--single-line-tags/--multi-line-tags",
+    is_flag=True,
+    default=False,
+    help=(
+        "If --single-line-tags given, output consecutive tags on one line. "
+        "If --multi-line-tags given, output one tag per line. "
+        "[default: --multi-line-tags]"
+    ),
+)
+@click.option(
     "--fast/--safe",
     is_flag=True,
     help="If --fast given, skip the sanity checks of file contents. [default: --safe]",
@@ -72,6 +82,7 @@ def main(
     check: bool,
     alignment: Optional[str],
     newline: Optional[str],
+    single_line_tags: bool,
     fast: bool,
     config: Optional[str],
 ) -> None:
@@ -84,11 +95,13 @@ def main(
     write_back_mode = WriteBackMode.from_configuration(check)
     alignment_mode = AlignmentMode.from_configuration(alignment)
     newline_mode = NewlineMode.from_configuration(newline)
+    tag_line_mode = TagLineMode.from_configuration(single_line_tags)
 
     options = Options(
         write_back=write_back_mode,
         step_keyword_alignment=alignment_mode,
         newline=newline_mode,
+        tag_line_mode=tag_line_mode,
         fast=fast,
     )
 

--- a/reformat_gherkin/core.py
+++ b/reformat_gherkin/core.py
@@ -106,7 +106,9 @@ def format_str(src_contents: str, *, options: Options) -> str:
     """
     ast = parse(src_contents)
 
-    line_generator = LineGenerator(ast, options.step_keyword_alignment)
+    line_generator = LineGenerator(
+        ast, options.step_keyword_alignment, options.tag_line_mode
+    )
     lines = line_generator.generate()
 
     return "\n".join(lines)

--- a/reformat_gherkin/formatter.py
+++ b/reformat_gherkin/formatter.py
@@ -1,5 +1,5 @@
-from itertools import chain, zip_longest
-from typing import Any, Dict, Iterator, List, Mapping, Optional, Set, Union
+from itertools import chain
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Set, Union
 
 from attr import attrib, dataclass
 
@@ -19,13 +19,8 @@ from .ast_node import (
     TableRow,
     Tag,
 )
-from .options import AlignmentMode
-from .utils import (
-    camel_to_snake_case,
-    extract_beginning_spaces,
-    get_display_width,
-    get_step_keywords,
-)
+from .options import AlignmentMode, TagLineMode
+from .utils import camel_to_snake_case, get_display_width, get_step_keywords
 
 INDENT = "  "
 INDENT_LEVEL_MAP: Mapping[Any, int] = {
@@ -192,6 +187,7 @@ Lines = Iterator[str]
 class LineGenerator:
     ast: GherkinDocument
     step_keyword_alignment: AlignmentMode
+    tag_line_mode: TagLineMode
     __nodes: List[Node] = attrib(init=False)
     __contexts: ContextMap = attrib(init=False)
     __nodes_with_newline: Set[Node] = attrib(init=False)
@@ -209,9 +205,9 @@ class LineGenerator:
         properly format these lines.
         """
         contexts: ContextMap = {}
-        nodes = self.__nodes
+        comment_parent = None
 
-        for node in nodes:
+        for node in reversed(self.__nodes):
             # We want tags to have the same indentation level with their parents
             for tag in getattr(node, "tags", []):
                 contexts[tag] = node
@@ -226,10 +222,14 @@ class LineGenerator:
                 for row, line in zip(rows, lines):
                     contexts[row] = line
 
-        for node, next_node in zip_longest(nodes, nodes[1:], fillvalue=None):
             if isinstance(node, Comment):
-                # We want comments to have the same indentation level with the next line
-                contexts[node] = next_node
+                # We want comments to have the same indentation level as the nearest
+                # node that has an entry in the indent level map.
+                contexts[node] = comment_parent
+            elif (
+                type(node) in INDENT_LEVEL_MAP  # pylint: disable=unidiomatic-typecheck
+            ):
+                comment_parent = node
 
         return contexts
 
@@ -285,11 +285,74 @@ class LineGenerator:
         self.__contexts[language_header] = self.ast.feature
 
     def generate(self) -> Lines:
-        for node in self.__nodes:
-            yield from self.visit(node)
+        i = 0
+        while i < len(self.__nodes):
+            node = self.__nodes[i]
+            if isinstance(node, (Tag, Comment)):
+                # We need to treat comments and tags specially; if we are using
+                # TagLineMode.SINGLELINE then we might only yield one line for
+                # several tag nodes, and the order of the tags and comments may
+                # change.
+                comments_and_tags = []
+                for node in self.__nodes[i:]:
+                    if isinstance(node, (Tag, Comment)):
+                        comments_and_tags.append(node)
+                        i += 1
+                    else:
+                        break
+                yield from self.generate_comment_and_tag_lines(comments_and_tags)
+            else:
+                yield from self.visit(node)
+                i += 1
 
-            if node in self.__nodes_with_newline:
-                yield ""
+    def generate_comment_and_tag_lines(
+        self, comments_and_tags: Sequence[Union[Comment, Tag]]
+    ):
+        if self.tag_line_mode == TagLineMode.MULTILINE:
+            for node in comments_and_tags:
+                yield from self.visit(node)
+        else:
+            # For single-line tags, the order of the tags and comments can be
+            # switched. For example:
+            #
+            #   # Comment 1
+            #   @tag1 @tag2
+            #   # Comment 2
+            #   @tag3
+            #   # Comment 3
+            #
+            # is rendered as:
+            #
+            #   # Comment 1
+            #   # Comment 2
+            #   @tag1 @tag2 @tag3
+            #   # Comment 3
+            #
+            # To enable reordering, we split our input nodes into three
+            # categories: comments that go before the tags, the tags, and
+            # comments that go after the tags. Once we have separated the nodes,
+            # we then render each of the categories in turn.
+            comments_before: List[Comment] = []
+            tags: List[Tag] = []
+            comments_after: List[Comment] = []
+            for node in reversed(comments_and_tags):
+                if isinstance(node, Comment):
+                    if tags:
+                        comments_before.append(node)
+                    else:
+                        comments_after.append(node)
+                else:
+                    tags.append(node)
+
+            for comment in reversed(comments_before):
+                yield from self.visit(comment)
+            if tags:
+                context = self.__contexts[tags[0]]
+                indent_level = INDENT_LEVEL_MAP[type(context)]
+                tag_string = " ".join(tag.name for tag in reversed(tags))
+                yield f"{INDENT * indent_level}{tag_string}"
+            for comment in reversed(comments_after):
+                yield from self.visit(comment)
 
     def visit(self, node: Node) -> Lines:
         class_name = type(node).__name__
@@ -297,6 +360,8 @@ class LineGenerator:
         yield from getattr(
             self, f"visit_{camel_to_snake_case(class_name)}", self.visit_default
         )(node)
+        if node in self.__nodes_with_newline:
+            yield ""
 
     @staticmethod
     def visit_default(node: Node) -> Lines:
@@ -334,21 +399,15 @@ class LineGenerator:
 
         # Find the indent level of this comment line
         if context is None:
-            # In this case, this comment line is the last line of the document
-            indent_level: Optional[int] = 0
+            # Comments that have no context are at the end of the document
+            indent_level = 0
         else:
-            # Try to look for the indent level of the context in the mapping. If not
-            # successful, then we use the same amount of white spaces to indent as
-            # the next line.
-            indent_level = INDENT_LEVEL_MAP.get(type(context))
+            # Look up the indent level of the context in the indent level map.
+            # All contexts for comments have an entry in the map, so we don't
+            # have to worry about KeyError here.
+            indent_level = INDENT_LEVEL_MAP[type(context)]
 
-        if indent_level is None:
-            next_line = next(self.visit(context))
-            indent = extract_beginning_spaces(next_line)
-        else:
-            indent = INDENT * indent_level
-
-        yield f"{indent}{comment.text}"
+        yield f"{INDENT * indent_level}{comment.text}"
 
     @staticmethod
     def visit_doc_string(docstring: DocString) -> Lines:

--- a/reformat_gherkin/options.py
+++ b/reformat_gherkin/options.py
@@ -36,9 +36,20 @@ class NewlineMode(Enum):
         return NewlineMode(newline)
 
 
+@unique
+class TagLineMode(Enum):
+    SINGLELINE = "singleline"
+    MULTILINE = "multiline"
+
+    @classmethod
+    def from_configuration(cls, single_line_tags: bool) -> "TagLineMode":
+        return TagLineMode.SINGLELINE if single_line_tags else TagLineMode.MULTILINE
+
+
 @dataclass(frozen=True)
 class Options:
     write_back: WriteBackMode
     step_keyword_alignment: AlignmentMode
     newline: NewlineMode
+    tag_line_mode: TagLineMode
     fast: bool

--- a/reformat_gherkin/utils.py
+++ b/reformat_gherkin/utils.py
@@ -65,13 +65,6 @@ def get_step_keywords(dialect_name="en") -> List[str]:
     return [kw.strip() for kw in keywords]
 
 
-_beginning_spaces_re = re.compile(r"^(\s*).*")
-
-
-def extract_beginning_spaces(string: str) -> str:
-    return _beginning_spaces_re.findall(string)[0]
-
-
 def remove_trailing_spaces(string: str) -> str:
     lines = string.splitlines()
     return "\n".join(line.rstrip() for line in lines)

--- a/tests/data/valid/full/expected_single_line_tags.feature
+++ b/tests/data/valid/full/expected_single_line_tags.feature
@@ -1,0 +1,53 @@
+@tag-1 @tag-2
+Feature: Some meaningful feature
+  Some meaningful feature description
+
+  Background: A solid background
+    Some description for this background
+      This description has multiple lines
+
+    Given A lot of money
+      | EUR |
+      | USD |
+      | VND |
+
+  @tag-no-1 @decorate-1 @fixture-1
+  Scenario: Gain a lot of money
+    This is a description for this scenario
+
+    Given I go to the bank
+    Then I rob the bank
+
+  # Some comment here...
+  @tag-no-2 @decorate-2 @prepare-2 @fixture-2
+  # Another comment...
+  Scenario Outline: Break the bank's vault
+    A description for this scenario outline
+
+    # Is it helpful to put a comment here?
+    Given I stand in front of the bank's vault
+    And I break the vault's door
+    """
+    Some docstring here
+      A docstring can have multiple lines
+        With indentation
+    """
+    Then I enter the vault
+    """
+    Some docstring there
+    """
+    And I see a lot of money
+
+    # Examples can have tags? Hmmm...
+    @test-examples-tags
+    Examples: Continents
+      This is the description for these examples
+
+      | Asia    | 111 |
+      | Europe  | 22  |
+      # We can even have a comment in the middle of a table
+      | America | 3   |
+      # Pipe characters in table cells need to be escaped
+      | a \| b  | 4   |
+
+# Some random comment at the end of the document

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,11 +1,20 @@
-from reformat_gherkin.options import AlignmentMode, NewlineMode, Options, WriteBackMode
+from reformat_gherkin.options import (
+    AlignmentMode,
+    NewlineMode,
+    Options,
+    TagLineMode,
+    WriteBackMode,
+)
 
 
-def make_options(alignment_mode):
+def make_options(
+    step_keyword_alignment=AlignmentMode.NONE, tag_line_mode=TagLineMode.MULTILINE
+):
     return Options(
         write_back=WriteBackMode.CHECK,
-        step_keyword_alignment=alignment_mode,
+        step_keyword_alignment=step_keyword_alignment,
         newline=NewlineMode.KEEP,
+        tag_line_mode=tag_line_mode,
         fast=False,
     )
 
@@ -14,9 +23,10 @@ OPTIONS = [make_options(alignment_mode) for alignment_mode in AlignmentMode]
 
 
 FILENAME_OPTION_MAP = {
-    "expected_default": make_options(AlignmentMode.NONE),
-    "expected_left_aligned": make_options(AlignmentMode.LEFT),
-    "expected_right_aligned": make_options(AlignmentMode.RIGHT),
+    "expected_default": make_options(step_keyword_alignment=AlignmentMode.NONE),
+    "expected_left_aligned": make_options(step_keyword_alignment=AlignmentMode.LEFT),
+    "expected_right_aligned": make_options(step_keyword_alignment=AlignmentMode.RIGHT),
+    "expected_single_line_tags": make_options(tag_line_mode=TagLineMode.SINGLELINE),
 }
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,10 +1,12 @@
 from reformat_gherkin.ast_node import GherkinDocument
 from reformat_gherkin.formatter import LineGenerator
-from reformat_gherkin.options import AlignmentMode
+from reformat_gherkin.options import AlignmentMode, TagLineMode
 
 
-def format_ast(ast, alignment_mode=AlignmentMode.LEFT):
-    line_generator = LineGenerator(ast, alignment_mode)
+def format_ast(
+    ast, alignment_mode=AlignmentMode.LEFT, tag_line_mode=TagLineMode.MULTILINE
+):
+    line_generator = LineGenerator(ast, alignment_mode, tag_line_mode)
     lines = line_generator.generate()
     return "\n".join(lines)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,14 +33,6 @@ def test_dump_to_file(output, content):
     os.remove(name)
 
 
-def test_extract_beginning_spaces():
-    f = utils.extract_beginning_spaces
-
-    assert f("asd") == ""
-    assert f("   asd") == "   "
-    assert f(" asd  ") == " "
-
-
 def test_remove_trailing_spaces():
     f = utils.remove_trailing_spaces
 


### PR DESCRIPTION
Add a --single-line-tags option, which causes consecutive tags to be
output on a single line. Also add a --multi-line-tags option to
explicitly specify the current default behaviour of outputting one tag
per line.

When the --single-line-tags option is specified, tags separated by
comments are merged into one line, as discussed in issue #22.