### PR TITLE
Align step keywords to the longest keyword in the current scenario

### DIFF
--- a/reformat_gherkin/utils.py
+++ b/reformat_gherkin/utils.py
@@ -4,10 +4,9 @@ import re
 import tempfile
 import tokenize
 from functools import lru_cache, partial
-from typing import List, Tuple
+from typing import Tuple
 
 import click
-from gherkin.dialect import Dialect
 from wcwidth import wcswidth
 
 out = partial(click.secho, bold=True, err=True)
@@ -50,21 +49,6 @@ def diff(a: str, b: str, a_name: str, b_name: str) -> str:
     )
 
 
-@lru_cache()
-def get_step_keywords(dialect_name="en") -> List[str]:
-    dialect = Dialect.for_name(dialect_name)
-
-    keywords = (
-        dialect.given_keywords
-        + dialect.when_keywords
-        + dialect.then_keywords
-        + dialect.and_keywords
-        + dialect.but_keywords
-    )
-
-    return [kw.strip() for kw in keywords]
-
-
 _beginning_spaces_re = re.compile(r"^(\s*).*")
 
 
@@ -95,6 +79,7 @@ def decode_bytes(src: bytes) -> Tuple[str, str, str]:
         return tiow.read(), encoding, newline
 
 
+@lru_cache()
 def get_display_width(text: str) -> int:
     """
     Get the display width of a string.

--- a/tests/data/valid/german/expected_left_aligned.feature
+++ b/tests/data/valid/german/expected_left_aligned.feature
@@ -1,0 +1,14 @@
+# language: de
+
+# A comment.
+@tag1
+Funktionalität: Division
+  Um Fehler zu vermeiden, müssen die Kassierer in der Lage sein,
+  Divisionen auszurechnen
+
+  Szenario: Regular numbers
+    Angenommen ich habe die Zahl 3 im Taschenrechner eingegeben
+    Und        ich habe die Taste "Division" gedrückt
+    Und        ich habe die Zahl 2 im Taschenrechner eingegeben
+    Wenn       ich auf die Taste "Gleich" drücke
+    Dann       sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/german/expected_right_aligned.feature
+++ b/tests/data/valid/german/expected_right_aligned.feature
@@ -1,0 +1,14 @@
+# language: de
+
+# A comment.
+@tag1
+Funktionalität: Division
+  Um Fehler zu vermeiden, müssen die Kassierer in der Lage sein,
+  Divisionen auszurechnen
+
+  Szenario: Regular numbers
+    Angenommen ich habe die Zahl 3 im Taschenrechner eingegeben
+           Und ich habe die Taste "Division" gedrückt
+           Und ich habe die Zahl 2 im Taschenrechner eingegeben
+          Wenn ich auf die Taste "Gleich" drücke
+          Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/japanese/expected_left_aligned.feature
+++ b/tests/data/valid/japanese/expected_left_aligned.feature
@@ -1,0 +1,8 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+
+  シナリオ: Aligning step keywords with wide characters
+    前提   I have a Japanese Gherkin document
+    もし   I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/japanese/expected_right_aligned.feature
+++ b/tests/data/valid/japanese/expected_right_aligned.feature
@@ -1,0 +1,8 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+
+  シナリオ: Aligning step keywords with wide characters
+      前提 I have a Japanese Gherkin document
+      もし I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/japanese/input.feature
+++ b/tests/data/valid/japanese/input.feature
@@ -1,0 +1,7 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+  シナリオ: Aligning step keywords with wide characters
+    前提 I have a Japanese Gherkin document
+    もし I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/no_given_step/expected_left_aligned.feature
+++ b/tests/data/valid/no_given_step/expected_left_aligned.feature
@@ -1,0 +1,5 @@
+Feature: Feature name
+
+  Scenario: Scenario name
+    When I do something
+    Then I get a result

--- a/tests/data/valid/no_given_step/expected_right_aligned.feature
+++ b/tests/data/valid/no_given_step/expected_right_aligned.feature
@@ -1,0 +1,5 @@
+Feature: Feature name
+
+  Scenario: Scenario name
+    When I do something
+    Then I get a result

--- a/tests/data/valid/no_given_step/input.feature
+++ b/tests/data/valid/no_given_step/input.feature
@@ -1,0 +1,4 @@
+Feature: Feature name
+  Scenario: Scenario name
+    When I do something
+    Then I get a result


### PR DESCRIPTION
When --alignment left or --alignment right is specified, align step
keywords to the longest keyword in the current scenario, instead of the
longest keyword of all keywords for the current Gherkin dialect. This
fixes step keyword alignment for English scenarios with no "Given" step, and
also fixes a problem where the Gherkin dialect was always treated as
English for the purpose of finding step keyword length.

Fixes: #27