### PR TITLE
Align step text to the longest keyword in the document

### DIFF
--- a/reformat_gherkin/formatter.py
+++ b/reformat_gherkin/formatter.py
@@ -20,12 +20,7 @@ from .ast_node import (
     Tag,
 )
 from .options import AlignmentMode
-from .utils import (
-    camel_to_snake_case,
-    extract_beginning_spaces,
-    get_display_width,
-    get_step_keywords,
-)
+from .utils import camel_to_snake_case, extract_beginning_spaces, get_display_width
 
 INDENT = "  "
 INDENT_LEVEL_MAP: Mapping[Any, int] = {
@@ -44,7 +39,7 @@ def generate_language_header(language: str) -> Comment:
 
 
 def generate_step_line(
-    step: Step, keyword_alignment: AlignmentMode, *, dialect_name: str = "en"
+    step: Step, keyword_alignment: AlignmentMode, *, keyword_padding_width: int = 0
 ) -> str:
     """
     Generate lines for steps. The step keywords are aligned according to the parameter
@@ -68,24 +63,22 @@ def generate_step_line(
     indent_level: int = INDENT_LEVEL_MAP[Step]
 
     formatted_keyword = format_step_keyword(
-        step.keyword, keyword_alignment, dialect_name=dialect_name
+        step.keyword, keyword_alignment, keyword_padding_width=keyword_padding_width
     )
 
     return f"{INDENT * indent_level}{formatted_keyword} {step.text}"
 
 
 def format_step_keyword(
-    keyword: str, keyword_alignment: AlignmentMode, *, dialect_name: str = "en"
+    keyword: str, keyword_alignment: AlignmentMode, *, keyword_padding_width: int = 0
 ) -> str:
     """
     Insert padding to step keyword if necessary based on how we want to align them.
     """
-    if keyword_alignment is AlignmentMode.NONE:
+    if keyword_alignment is AlignmentMode.NONE or keyword_padding_width <= 0:
         return keyword
 
-    all_keywords = get_step_keywords(dialect_name)
-    max_keyword_length = max(map(len, all_keywords))
-    padding = " " * (max_keyword_length - len(keyword))
+    padding = " " * (keyword_padding_width - get_display_width(keyword))
 
     if keyword_alignment is AlignmentMode.LEFT:
         return keyword + padding
@@ -195,12 +188,14 @@ class LineGenerator:
     __nodes: List[Node] = attrib(init=False)
     __contexts: ContextMap = attrib(init=False)
     __nodes_with_newline: Set[Node] = attrib(init=False)
+    __max_step_keyword_width: int = attrib(init=False)
 
     def __attrs_post_init__(self):
         # Use `__attrs_post_init__` instead of `property` to avoid re-computing attributes
         self.__nodes = sorted(list(self.ast), key=lambda node: node.location)
         self.__contexts = self.__construct_contexts()
         self.__nodes_with_newline = self.__find_nodes_with_newline()
+        self.__max_step_keyword_width = self.__find_max_step_keyword_width()
         self.__add_language_header()
 
     def __construct_contexts(self) -> ContextMap:
@@ -268,6 +263,25 @@ class LineGenerator:
 
         return nodes_with_newline
 
+    def __find_max_step_keyword_width(self) -> int:
+        """
+        Find the length of the longest step keyword in the document. This is
+        used for aligning step keywords.
+        """
+        if self.step_keyword_alignment is AlignmentMode.NONE:
+            # We don't need to align step keywords in this case.
+            return 0
+
+        step_keyword_widths = [
+            get_display_width(node.keyword.strip())
+            for node in self.ast
+            if isinstance(node, Step)
+        ]
+        if not step_keyword_widths:
+            return 0
+
+        return max(step_keyword_widths)
+
     def __add_language_header(self) -> None:
         """Add a language header if the Feature language is not English."""
         # Exit if the language is English or if there is no Feature node
@@ -313,7 +327,11 @@ class LineGenerator:
             )
 
     def visit_step(self, step: Step) -> Lines:
-        yield generate_step_line(step, self.step_keyword_alignment)
+        yield generate_step_line(
+            step,
+            self.step_keyword_alignment,
+            keyword_padding_width=self.__max_step_keyword_width,
+        )
 
     def visit_tag(self, tag: Tag) -> Lines:
         context = self.__contexts[tag]

--- a/reformat_gherkin/utils.py
+++ b/reformat_gherkin/utils.py
@@ -4,10 +4,9 @@ import re
 import tempfile
 import tokenize
 from functools import lru_cache, partial
-from typing import List, Tuple
+from typing import Tuple
 
 import click
-from gherkin.dialect import Dialect
 from wcwidth import wcswidth
 
 out = partial(click.secho, bold=True, err=True)
@@ -50,21 +49,6 @@ def diff(a: str, b: str, a_name: str, b_name: str) -> str:
     )
 
 
-@lru_cache()
-def get_step_keywords(dialect_name="en") -> List[str]:
-    dialect = Dialect.for_name(dialect_name)
-
-    keywords = (
-        dialect.given_keywords
-        + dialect.when_keywords
-        + dialect.then_keywords
-        + dialect.and_keywords
-        + dialect.but_keywords
-    )
-
-    return [kw.strip() for kw in keywords]
-
-
 _beginning_spaces_re = re.compile(r"^(\s*).*")
 
 
@@ -95,6 +79,7 @@ def decode_bytes(src: bytes) -> Tuple[str, str, str]:
         return tiow.read(), encoding, newline
 
 
+@lru_cache()
 def get_display_width(text: str) -> int:
     """
     Get the display width of a string.

--- a/tests/data/valid/full/expected_default.feature
+++ b/tests/data/valid/full/expected_default.feature
@@ -56,4 +56,8 @@ Feature: Some meaningful feature
       # Pipe characters in table cells need to be escaped
       | a \| b  | 4   |
 
+  Scenario: Escaping the bank
+    When I exit the bank
+    Then the police will start to chase me
+
 # Some random comment at the end of the document

--- a/tests/data/valid/full/expected_left_aligned.feature
+++ b/tests/data/valid/full/expected_left_aligned.feature
@@ -56,4 +56,8 @@ Feature: Some meaningful feature
       # Pipe characters in table cells need to be escaped
       | a \| b  | 4   |
 
+  Scenario: Escaping the bank
+    When  I exit the bank
+    Then  the police will start to chase me
+
 # Some random comment at the end of the document

--- a/tests/data/valid/full/expected_right_aligned.feature
+++ b/tests/data/valid/full/expected_right_aligned.feature
@@ -56,4 +56,8 @@ Feature: Some meaningful feature
       # Pipe characters in table cells need to be escaped
       | a \| b  | 4   |
 
+  Scenario: Escaping the bank
+     When I exit the bank
+     Then the police will start to chase me
+
 # Some random comment at the end of the document

--- a/tests/data/valid/full/input.feature
+++ b/tests/data/valid/full/input.feature
@@ -60,5 +60,8 @@ Feature: Some meaningful feature
       # Pipe characters in table cells need to be escaped
       | a \| b        | 4 |
 
+  Scenario: Escaping the bank
+     When I exit the bank
+     Then the police will start to chase me
 
     # Some random comment at the end of the document

--- a/tests/data/valid/german/expected_default.feature
+++ b/tests/data/valid/german/expected_default.feature
@@ -12,3 +12,7 @@ Funktionalität: Division
     Und ich habe die Zahl 2 im Taschenrechner eingegeben
     Wenn ich auf die Taste "Gleich" drücke
     Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden
+
+  Szenario: Regular numbers (short)
+    Wenn ich auf die Taste "Gleich" drücke
+    Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/german/expected_left_aligned.feature
+++ b/tests/data/valid/german/expected_left_aligned.feature
@@ -1,0 +1,18 @@
+# language: de
+
+# A comment.
+@tag1
+Funktionalität: Division
+  Um Fehler zu vermeiden, müssen die Kassierer in der Lage sein,
+  Divisionen auszurechnen
+
+  Szenario: Regular numbers
+    Angenommen ich habe die Zahl 3 im Taschenrechner eingegeben
+    Und        ich habe die Taste "Division" gedrückt
+    Und        ich habe die Zahl 2 im Taschenrechner eingegeben
+    Wenn       ich auf die Taste "Gleich" drücke
+    Dann       sollte als Resultat 1,5 am Bildschirm ausgegeben werden
+
+  Szenario: Regular numbers (short)
+    Wenn       ich auf die Taste "Gleich" drücke
+    Dann       sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/german/expected_right_aligned.feature
+++ b/tests/data/valid/german/expected_right_aligned.feature
@@ -1,0 +1,18 @@
+# language: de
+
+# A comment.
+@tag1
+Funktionalität: Division
+  Um Fehler zu vermeiden, müssen die Kassierer in der Lage sein,
+  Divisionen auszurechnen
+
+  Szenario: Regular numbers
+    Angenommen ich habe die Zahl 3 im Taschenrechner eingegeben
+           Und ich habe die Taste "Division" gedrückt
+           Und ich habe die Zahl 2 im Taschenrechner eingegeben
+          Wenn ich auf die Taste "Gleich" drücke
+          Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden
+
+  Szenario: Regular numbers (short)
+          Wenn ich auf die Taste "Gleich" drücke
+          Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/german/input.feature
+++ b/tests/data/valid/german/input.feature
@@ -12,3 +12,7 @@ Funktionalität: Division
         Und ich habe die Zahl 2 im Taschenrechner eingegeben
         Wenn ich auf die Taste "Gleich" drücke
         Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden
+
+    Szenario: Regular numbers (short)
+        Wenn ich auf die Taste "Gleich" drücke
+        Dann sollte als Resultat 1,5 am Bildschirm ausgegeben werden

--- a/tests/data/valid/japanese/expected_left_aligned.feature
+++ b/tests/data/valid/japanese/expected_left_aligned.feature
@@ -1,0 +1,8 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+
+  シナリオ: Aligning step keywords with wide characters
+    前提   I have a Japanese Gherkin document
+    もし   I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/japanese/expected_right_aligned.feature
+++ b/tests/data/valid/japanese/expected_right_aligned.feature
@@ -1,0 +1,8 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+
+  シナリオ: Aligning step keywords with wide characters
+      前提 I have a Japanese Gherkin document
+      もし I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/japanese/input.feature
+++ b/tests/data/valid/japanese/input.feature
@@ -1,0 +1,7 @@
+# language: ja
+
+フィーチャ: Japanese Gherkin documents
+  シナリオ: Aligning step keywords with wide characters
+    前提 I have a Japanese Gherkin document
+    もし I run reformat-gherkin with an alignment option
+    ならば the step keywords should be aligned

--- a/tests/data/valid/no_given_step/expected_left_aligned.feature
+++ b/tests/data/valid/no_given_step/expected_left_aligned.feature
@@ -1,0 +1,5 @@
+Feature: Feature name
+
+  Scenario: Scenario name
+    When I do something
+    Then I get a result

--- a/tests/data/valid/no_given_step/expected_right_aligned.feature
+++ b/tests/data/valid/no_given_step/expected_right_aligned.feature
@@ -1,0 +1,5 @@
+Feature: Feature name
+
+  Scenario: Scenario name
+    When I do something
+    Then I get a result

--- a/tests/data/valid/no_given_step/input.feature
+++ b/tests/data/valid/no_given_step/input.feature
@@ -1,0 +1,4 @@
+Feature: Feature name
+  Scenario: Scenario name
+    When I do something
+    Then I get a result


### PR DESCRIPTION
When --alignment left or --alignment right is specified, align step text
to the longest keyword in the document, instead of the longest keyword
of all keywords for the current Gherkin dialect. This prevents extra
padding spaces from being displayed for documents that don't use the
longest available keyword. It also fixes a problem where non-English
documents were treated as having English keywords for the purposes of
step keyword alignment.

Fixes: #27