### PR TITLE
Escape triple quotes in doc strings

### DIFF
--- a/reformat_gherkin/ast_node/doc_string.py
+++ b/reformat_gherkin/ast_node/doc_string.py
@@ -1,10 +1,17 @@
+from attr import attrib
+
 from ._base import prepare
 from .location import LocationMixin
 
 
+def escape_doc_string_value(text: str) -> str:
+    """Escape triple-quotes in doc strings."""
+    return text.replace('"""', '\\"\\"\\"')
+
+
 @prepare
 class DocString(LocationMixin):
-    content: str
+    content: str = attrib(converter=escape_doc_string_value)
 
     def __iter__(self):
         yield self

--- a/tests/data/valid/doc_string_escape/expected_default.feature
+++ b/tests/data/valid/doc_string_escape/expected_default.feature
@@ -1,0 +1,28 @@
+Feature: Docstrings
+
+  Scenario: Escaping docstrings
+    Given I have a docstring
+    """
+    This docstring has \"escaped\" double quotes.
+    It also has \`escaped\` backticks.
+    """
+    And I have a docstring with an escaped docstring in
+    """
+    This is another docstring.
+      \"\"\"
+      It has an escaped docstring inside it.
+      \"\"\"
+    """
+    And I have a backtick docstring
+    """
+    This docstring has \"escaped\" double quotes.
+    It also has \`escaped\` backticks.
+    """
+    And I have a nested single-quote docstring
+    """
+    This is a backtick docstring.
+      \`\`\`
+      It also has an escaped docstring inside it.
+      \`\`\`
+    """
+    Then the escaped characters are printed when the document is reformatted

--- a/tests/data/valid/doc_string_escape/input.feature
+++ b/tests/data/valid/doc_string_escape/input.feature
@@ -1,0 +1,27 @@
+Feature: Docstrings
+  Scenario: Escaping docstrings
+    Given I have a docstring
+      """
+      This docstring has \"escaped\" double quotes.
+      It also has \`escaped\` backticks.
+      """
+    And I have a docstring with an escaped docstring in
+      """
+      This is another docstring.
+        \"\"\"
+        It has an escaped docstring inside it.
+        \"\"\"
+      """
+    And I have a backtick docstring
+      ```
+      This docstring has \"escaped\" double quotes.
+      It also has \`escaped\` backticks.
+      ```
+    And I have a nested single-quote docstring
+      ```
+      This is a backtick docstring.
+        \`\`\`
+        It also has an escaped docstring inside it.
+        \`\`\`
+      ```
+    Then the escaped characters are printed when the document is reformatted


### PR DESCRIPTION
If a doc string contains escaped triple quotes, then they must also be
escaped when reformatting, otherwise the resulting document will be
invalid.

Fixes #31