### PR TITLE
Prevent Gherkin from using feature contents as paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ reformat-gherkin = "reformat_gherkin.cli:main"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-gherkin-official = "^4.1"
+gherkin-official = "4.1.3"
 click = "^7.0"
 attrs = "^19.2"
 cattrs = "^1.0.0"

--- a/tests/data/valid/large_file/expected_default.feature
+++ b/tests/data/valid/large_file/expected_default.feature
@@ -1,0 +1,1722 @@
+# This feature file is 34KB in size.
+Feature: A feature
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens
+
+  Scenario: A scenario
+    Given some precondition
+    When I do something
+    Then something happens

--- a/tests/data/valid/large_file/input.feature
+++ b/tests/data/valid/large_file/input.feature
@@ -1,0 +1,1723 @@
+# This feature file is 34KB in size.
+
+Feature: A feature
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens
+
+	Scenario: A scenario
+		Given some precondition
+		When I do something
+		Then something happens


### PR DESCRIPTION
Subclass the gherkin-official TokenScanner class so that it doesn't
treat the feature contents as a path on the file system. This is
necessary to prevent "path too long for Windows" errors for feature
files larger than 32KB.

Also pin the gherkin-official version to 4.1.3, as we now depend on
Gherkin internals.

Fixes #34