### PR TITLE
:bug: Blank lines in docstrings have spaces added

### DIFF
--- a/reformat_gherkin/formatter.py
+++ b/reformat_gherkin/formatter.py
@@ -180,7 +180,7 @@ def generate_doc_string_lines(docstring: DocString, indent: str) -> List[str]:
 
     indent_level = INDENT_LEVEL_MAP[Step]
 
-    return [f"{indent * indent_level}{line}" for line in raw_lines]
+    return [f"{indent * indent_level}{line}" if line else "" for line in raw_lines]
 
 
 ContextMap = Dict[Union[Comment, Tag, TagGroup, TableRow], Any]

--- a/tests/data/valid/doc_string_with_spaces/expected_default.feature
+++ b/tests/data/valid/doc_string_with_spaces/expected_default.feature
@@ -1,0 +1,19 @@
+Feature: Docstrings with spaces
+
+  Scenario: Removing spaces from docstrings
+    Given I have a docstring
+    """
+    This docstring has spaces after the last word
+    """
+    And There is a docstring with populated blank lines in it
+    """
+    This docstring has an empty line in it
+
+    That empty line has spaces on it
+    """
+    And There is a docstring with unpopulated blank lines in it
+    """
+    This docstring has an empty line in it
+
+    That empty line has no spaces on it
+    """

--- a/tests/data/valid/doc_string_with_spaces/input.feature
+++ b/tests/data/valid/doc_string_with_spaces/input.feature
@@ -1,0 +1,18 @@
+Feature: Docstrings with spaces
+  Scenario: Removing spaces from docstrings
+    Given I have a docstring
+      """
+        This docstring has spaces after the last word     
+      """
+    And There is a docstring with populated blank lines in it
+      """
+        This docstring has an empty line in it
+        
+        That empty line has spaces on it
+      """
+    And There is a docstring with unpopulated blank lines in it
+      """
+        This docstring has an empty line in it
+
+        That empty line has no spaces on it
+      """


### PR DESCRIPTION
Problem:
- `reformat-gherkin` should strip all trailing spaces from docstrings.
  It currently adds spaces to blank lines in docstrings

Solution:
- Only output indent if the line is non-empty.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
